### PR TITLE
Sometimes user has no realm

### DIFF
--- a/src/artifactory_api_client.py
+++ b/src/artifactory_api_client.py
@@ -15,7 +15,7 @@ class ArtifactoyApiClient:
         realms = {}
 
         for user in users:
-            realm = user['realm']
+            realm = user.get('realm', 'none')
             if realm not in realms:
                 realms[realm] = 0
             realms[realm] += 1


### PR DESCRIPTION
Some special users (when integrating with other tools) have no realm, this crashes the exporter. This should fix it and report such users with `none` realm.